### PR TITLE
Bugfix: generating structure with unreadable file/folder now errors silently

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,7 +2,6 @@ name: Checks
 
 on:
   pull_request:
-    branches: [main]
 
 jobs:
   checks:

--- a/src/errors/DirectoryReadError.ts
+++ b/src/errors/DirectoryReadError.ts
@@ -1,6 +1,0 @@
-export class DirectoryReadError extends Error {
-  constructor(dirPath: string, originalError: Error) {
-    super(`Failed to read directory ${dirPath}: ${originalError.message}`);
-    this.name = 'DirectoryReadError';
-  }
-}

--- a/src/test/suite/getDirectoryStructure.test.ts
+++ b/src/test/suite/getDirectoryStructure.test.ts
@@ -111,7 +111,7 @@ suite('getDirectoryStructure', () => {
     expect(result).to.equal(expected);
   });
 
-  test('it should elements that fail to stat are files and move on', async () => {
+  test('it should print files and directories that fail to stat successfully', async () => {
     const fileSystemStructure = {
       root: {
         file1: '',
@@ -139,7 +139,7 @@ suite('getDirectoryStructure', () => {
     expect(result).to.equal(expected);
   });
 
-  test('it should skip directories that fail to readdir', async () => {
+  test('it should skip reading contents of directories that fail to readdir', async () => {
     const fileSystemStructure = {
       root: {
         file1: '',

--- a/src/test/suite/getDirectoryStructure.test.ts
+++ b/src/test/suite/getDirectoryStructure.test.ts
@@ -1,4 +1,3 @@
-import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import { getDirectoryStructure } from '../../utils/getDirectoryStructure';
@@ -6,7 +5,6 @@ import { use, expect } from 'chai';
 import * as sinon from 'sinon';
 
 import * as sinonChai from 'sinon-chai';
-import { DirectoryReadError } from '../../errors/DirectoryReadError';
 import * as config from '../../utils/getConfiguration';
 const dedent = require('dedent');
 
@@ -113,15 +111,60 @@ suite('getDirectoryStructure', () => {
     expect(result).to.equal(expected);
   });
 
-  test('it should throw DirectoryReadError if cannot read directory', async () => {
-    readdirStub.rejects(new Error('Cannot read directory'));
+  test('it should elements that fail to stat are files and move on', async () => {
+    const fileSystemStructure = {
+      root: {
+        file1: '',
+        inaccessibleFile: '',
+        inaccessibleDir: {
+          file3: '',
+        },
+        dir1: {
+          file4: '',
+        },
+      },
+    };
 
-    try {
-      await getDirectoryStructure('root');
-      assert.fail('Expected DirectoryReadError was not thrown');
-    } catch (error: any) {
-      expect(error).to.be.instanceOf(DirectoryReadError);
-      expect(error.message).to.contain('Cannot read directory');
-    }
+    setupFileSystemMock(fileSystemStructure);
+
+    statStub.withArgs('root/inaccessibleDir').rejects(new Error('read error'));
+    statStub.withArgs('root/inaccessibleFile').rejects(new Error('read error'));
+
+    const result = (await getDirectoryStructure('root')).trim();
+    const expected = dedent`├─ file1
+                            ├─ inaccessibleFile
+                            ├─ inaccessibleDir
+                            └─ dir1
+                               └─ file4`.trim();
+    expect(result).to.equal(expected);
+  });
+
+  test('it should skip directories that fail to readdir', async () => {
+    const fileSystemStructure = {
+      root: {
+        file1: '',
+        file2: '',
+        inaccessibleDir: {
+          file3: '',
+        },
+        dir1: {
+          file4: '',
+        },
+      },
+    };
+
+    setupFileSystemMock(fileSystemStructure);
+
+    readdirStub
+      .withArgs('root/inaccessibleDir')
+      .rejects(new Error('read error'));
+
+    const result = (await getDirectoryStructure('root')).trim();
+    const expected = dedent`├─ file1
+                            ├─ file2
+                            ├─ inaccessibleDir
+                            └─ dir1
+                               └─ file4`.trim();
+    expect(result).to.equal(expected);
   });
 });

--- a/src/utils/getDirectoryStructure.ts
+++ b/src/utils/getDirectoryStructure.ts
@@ -2,40 +2,44 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Minimatch } from 'minimatch';
 import { getConfiguration } from './getConfiguration';
-import { DirectoryReadError } from '../errors/DirectoryReadError';
 
 export async function getDirectoryStructure(
   dirPath: string,
   prefix = ''
 ): Promise<string> {
   let entries: string[];
+
+  let structure = '';
+
   try {
     entries = await fs.promises.readdir(dirPath);
   } catch (err: any) {
-    throw new DirectoryReadError(dirPath, err);
+    console.warn('Failed to read directory: ', err);
+    return structure;
   }
 
   const ignorePatterns: string[] = getConfiguration('ignorePatterns') ?? [];
   const minimatches = ignorePatterns.map(pattern => new Minimatch(pattern));
 
-  let structure = '';
   const filteredDir = entries.filter(
     file => !minimatches.some(minimatch => minimatch.match(file))
   );
 
   for (const [index, file] of filteredDir.entries()) {
     const filePath = path.join(dirPath, file);
-
-    let isDirectory: boolean;
-    try {
-      isDirectory = (await fs.promises.stat(filePath)).isDirectory();
-    } catch (err) {
-      throw new Error(`Failed to stat ${filePath}: ${err}`);
-    }
-
     const isLastInDirectory = index === filteredDir.length - 1;
 
+    let isDirectory: boolean;
+
+    try {
+      isDirectory = (await fs.promises.stat(filePath))?.isDirectory();
+    } catch (err) {
+      console.warn(`Failed to stat ${filePath}: ${err}`);
+      isDirectory = false;
+    }
+
     structure += prefix + (isLastInDirectory ? '└─ ' : '├─ ') + file + '\n';
+
     if (isDirectory) {
       structure += await getDirectoryStructure(
         filePath,


### PR DESCRIPTION
no more error popup when file or directory read fails